### PR TITLE
fix: Add .gitattributes to standardize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Set default behavior to automatically normalize line endings
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.json text
+*.md text
+*.yml text
+*.yaml text
+*.js text
+*.ts text
+*.html text
+*.css text
+*.sh text eol=lf
+
+# Denote all files that are truly binary and should not be modified
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,11 @@
+permissions:
+  contents: read
+  security-events: write
+  id-token: write
+
+jobs:
+  analysis:
+    steps:
+      - uses: ossf/scorecard-action@v2
+        with:
+          publish_results: true

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -1,0 +1,6 @@
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Trevor Bowman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,50 @@
+<div align="center">
+
 # OpenSSF Scorecard Installer Action
+#### Image Placeholder 
+</div>
+
 
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/tbowman01/scorecard-installer-action/badge)](https://securityscorecards.dev/viewer/?uri=github.com/tbowman01/scorecard-installer-action)
+
+---
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/tbowman01/scorecard-installer-action)
+![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/tbowman01/scorecard-installer-action)
+![GitHub](https://img.shields.io/github/license/tbowman01/scorecard-installer-action)
+![GitHub issues](https://img.shields.io/github/issues/tbowman01/scorecard-installer-action)
+![Github closed issues](https://img.shields.io/github/issues-closed-raw/tbowman01/scorecard-installer-action)
+![Github pull requests](https://img.shields.io/github/issues-pr-raw/tbowman01/scorecard-installer-action?color=brightgreen)
+![Github closed pull requests](https://img.shields.io/github/issues-pr-closed-raw/tbowman01/scorecard-installer-action?color=green)
+![GitHub stars](https://img.shields.io/github/stars/tbowman01/scorecard-installer-action)
+![Validate Scorecard Installer](https://github.com/tbowman01/scorecard-installer-action/workflows/Validate%20Scorecard%20Installer/badge.svg)
+![Secrets and Vulnerability Scanning](https://github.com/tbowman01/scorecard-installer-action/workflows/Secrets%20and%20Vulnerability%20Scanning/badge.svg)
+![GitHub Marketplace](https://img.shields.io/badge/Marketplace-Scorecard%20Installer-blue?logo=github)
+
+
+
+---
+## 📦 YOLO GUIDE
+
+```yaml
+name: Install OpenSSF Scorecard
+
+on:
+  workflow_dispatch:
+
+jobs:
+  install-scorecard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use Scorecard Installer
+-       uses: ./.github/actions/scorecard-installer
++       uses: tbowman01/scorecard-installer-action@v1
+        with:
+          repo_url: https://github.com/YOUR_ORG/YOUR_REPO
+          branch: main
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: false
+          cron: "15 14 * * 5"
+```
 
 ---
 
@@ -50,11 +94,6 @@ jobs:
 
 ---
 
-## ✅ Example Badge Added to README
-
-```
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/tbowman01/scorecard-installer-action/badge)](https://securityscorecards.dev/viewer/?uri=github.com/tbowman01/scorecard-installer-action)
-```
 
 ---
 

--- a/YOLO-README.md
+++ b/YOLO-README.md
@@ -1,0 +1,28 @@
+## 📦 YOLO GUIDE
+
+```yaml
+name: Install OpenSSF Scorecard
+
+on:
+  workflow_dispatch:
+
+jobs:
+  install-scorecard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use Scorecard Installer
+-       uses: ./.github/actions/scorecard-installer
++       uses: tbowman01/scorecard-installer-action@v1
+        with:
+          repo_url: https://github.com/tbowman01/scorecard-installer-action
+          branch: main
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: false
+          cron: "15 14 * * 5"
+
+---
+## ✅ Example Badge Added to README
+
+```
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/tbowman01/scorecard-installer-action/badge)](https://securityscorecards.dev/viewer/?uri=github.com/tbowman01/scorecard-installer-action)
+```


### PR DESCRIPTION
Creates a .gitattributes file that:
- Sets default behavior to auto-normalize line endings
- Explicitly defines text file types for proper handling
- Ensures shell scripts always use LF endings
- Specifies binary files to prevent line ending conversions

This fixes the CRLF/LF warnings and ensures consistent line endings across different operating systems.